### PR TITLE
等速スラローム実装

### DIFF
--- a/custum_based_step7maze/adjust.c
+++ b/custum_based_step7maze/adjust.c
@@ -184,10 +184,36 @@ void adjust(void)
 				*					*
 				*****************************************/
 			
-				//センサーの前に手をかざしてスタート
-				if(sen_fr.value + sen_fl.value + sen_r.value + sen_l.value > SEN_DECISION * 4){
+				//右センサーの前に手をかざしてスタート
+				if(sen_fr.value + sen_r.value > SEN_DECISION * 2){
 					BEEP();
-
+					gyro_get_ref();
+					BEEP();
+					log_flag = 1;
+					log_timer = 0;
+					len_mouse = 0;
+					straight(SECTION,SEARCH_ACCEL,SEARCH_SPEED,SEARCH_SPEED);
+					slalom(RIGHT,SEARCH_SLA_ACCEL,SEARCH_SLA_SPEED);
+					log_flag = 0;
+					MOT_POWER_OFF;
+					wait_ms(1000);
+					BEEP();
+					wait_ms(500);		
+				}
+				//左センサーの前に手をかざしてスタート
+				if(sen_fl.value + sen_l.value > SEN_DECISION * 2){
+					BEEP();
+					gyro_get_ref();
+					BEEP();
+					log_flag = 1;
+					log_timer = 0;
+					len_mouse = 0;
+					straight(SECTION,SEARCH_ACCEL,SEARCH_SPEED,SEARCH_SPEED);
+					slalom(LEFT,SEARCH_SLA_ACCEL,SEARCH_SLA_SPEED);
+					log_flag = 0;
+					MOT_POWER_OFF;
+					wait_ms(1000);
+					BEEP();
 					wait_ms(500);		
 				}
 				

--- a/custum_based_step7maze/glob_var.h
+++ b/custum_based_step7maze/glob_var.h
@@ -45,6 +45,7 @@ GLOBAL float			speed;					//現在車体速度		[m/s]
 GLOBAL float			p_speed;				//過去の車体速度	[m/s]
 GLOBAL float			tar_speed;				//目標車体速度		[m/s]
 GLOBAL float			end_speed;				//終端車体速度		[m/s]
+GLOBAL float            add_speed;              //スラローム時の左右加算分速度  [m/s]
 GLOBAL float			V_r;					//右モータの出力電圧	[V]
 GLOBAL float			V_l;					//左モータの出力電圧	[V]
 

--- a/custum_based_step7maze/interrupt.c
+++ b/custum_based_step7maze/interrupt.c
@@ -19,7 +19,7 @@ void int_cmt0(void)
 		など
 	*****************************************************************************************/
 	//直線の場合の目標速度生成
-	if(run_mode == STRAIGHT_MODE){
+	if(run_mode == STRAIGHT_MODE || run_mode == SLA_MODE){
 		tar_speed += accel/1000.F;	//目標速度を設定加速度で更新
 		//最高速度制限
 		if(tar_speed > max_speed){
@@ -141,18 +141,18 @@ void int_cmt0(void)
 	*****************************************************************************************/
 	//フィードバック制御
 	V_r = V_l = 0.F;
-	if(run_mode == STRAIGHT_MODE || run_mode == TURN_MODE){
+	if(run_mode == STRAIGHT_MODE || run_mode == TURN_MODE || run_mode == SLA_MODE){
 	//直進時のフィードバック制御
 		//左右モータのフィードバック
 		//速度に対するP制御
-		V_r += 1.F * (tar_speed - speed) *SPEED_KP/1.F; //15目標値付近で発振
-		V_l += 1.F * (tar_speed - speed) *SPEED_KP/1.F;
+		V_r += 1.F * (tar_speed + add_speed - speed) *SPEED_KP/1.F; //15目標値付近で発振
+		V_l += 1.F * (tar_speed - add_speed - speed) *SPEED_KP/1.F;
 		//速度に対するI制御
-		V_r += 1.F * (I_tar_speed - I_speed) *SPEED_KI/1.F; //(0.4-0.3)*0.1 -> 0.01 
-		V_l += 1.F * (I_tar_speed - I_speed) *SPEED_KI/1.F;
+		V_r += 1.F * (I_tar_speed + add_speed - I_speed) *SPEED_KI/1.F; //(0.4-0.3)*0.1 -> 0.01 
+		V_l += 1.F * (I_tar_speed - add_speed - I_speed) *SPEED_KI/1.F;
 		//速度に対するD制御
-		V_r -= 1.F * (p_speed - speed) *SPEED_KD/1.F; //(0.4-0.3)*0.1 -> 0.01 
-		V_l -= 1.F * (p_speed - speed) *SPEED_KD/1.F;
+		V_r -= 1.F * (p_speed + add_speed - speed) *SPEED_KD/1.F; //(0.4-0.3)*0.1 -> 0.01 
+		V_l -= 1.F * (p_speed - add_speed - speed) *SPEED_KD/1.F;
 
 		//角速度に対するP制御
 		V_r += 1.F * (tar_ang_vel - ang_vel) *(OMEGA_KP/100.F);

--- a/custum_based_step7maze/parameters.h
+++ b/custum_based_step7maze/parameters.h
@@ -10,6 +10,13 @@
 #define ENC_RES_MAX	    (1024)
 #define ENC_RES_HALF	(512)
 
+#define CHASSIC_WIDTH   (40)        //シャーシ幅
+#define TIRE_WIDTH 	    (3)         //タイヤ幅
+#define SLA_RADIUS      (HALF_SECTION)   //スラローム半径
+#define SLA_RADIUS_PLUS ((CHASSIC_WIDTH/2.0)-(TIRE_WIDTH/2.0))  //内外輪と中心とのスラローム半径の差
+#define SLA_OUTER_RADIUS      (SLA_RADIUS+SLA_RADIUS_PLUS)   //外輪のスラローム半径(未使用)
+#define SLA_INNER_RADIUS      (SLA_RADIUS-SLA_RADIUS_PLUS)   //内輪のスラローム半径(未使用)
+
 #define V_ref		3.8				//モータ制御の基準電圧
 
 //ログ用のパラメータ
@@ -53,6 +60,12 @@
 #define TURN_ACCEL	    (PI*2)				//超信地旋回の加速度	[rad/s^2]
 #define	TURN_SPEED	    (PI)				//超信地旋回の最高速度	[rad/s]
 #define TURN_MIN_SPEED	(PI/10.0)			//超信地旋回の最低速度	[rad/s]
+
+#define SEARCH_SLA_SPEED        (SEARCH_SPEED)                              //スラローム速度
+#define SEARCH_SLA_SPEED_PLUS   (SEARCH_SPEED*SLA_RADIUS_PLUS/SLA_RADIUS)   //内外輪と中心のスラローム速度の差
+#define SEARCH_SLA_OUTER_SPEED  (SEARCH_SPEED*SLA_OUTER_RADIUS/SLA_RADIUS)  //外輪のスラローム速度(未使用)
+#define SEARCH_SLA_INNER_SPEED  (SEARCH_SPEED*SLA_INNER_RADIUS/SLA_RADIUS)  //内輪のスラローム速度(未使用)
+#define SEARCH_SLA_ACCEL        (SEARCH_ACCEL)                              //スラローム加速度
 
 #define WAIT_TIME	10				//各動作後の待機時間	[ms]
 

--- a/custum_based_step7maze/run.h
+++ b/custum_based_step7maze/run.h
@@ -1,2 +1,3 @@
 void straight(float len, float acc, float max_sp, float end_sp);
 void turn(int deg, float ang_acc, float max_om, short dir);
+void slalom(int deg, float acc, float end_sp);


### PR DESCRIPTION
・slalom関数追加
・adjust関数のcase5で、1区画直進後にスラローム
　（スラローム方向は手をかざした方向）
(注)台形駆動スラロームではない
(注)タイヤ幅3mmの中央で計算しているため、スピード上げて遠心力がかかる場合は半径の微調整が必要かもしれない
(注)コースでは動作未確認